### PR TITLE
Update train.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 - Pytorch implementation of the paper: "FaceNet: A Unified Embedding for Face Recognition and Clustering".
 - Training of network is done using triplet loss.
 
+# Difference from Main Repository
+- This repository takes advantage of Pytorch's DataParallel capacities to experience a much faster training time.
+
 
 # How to train/validate model
 - Download vggface2 (for training) and lfw (for validation) datasets.

--- a/train.py
+++ b/train.py
@@ -50,8 +50,13 @@ l2_dist = PairwiseDistance(2)
 
 
 def main():
+    parallel = False
     
     model     = FaceNetModel(embedding_size = args.embedding_size, num_classes = args.num_classes).to(device)
+    if torch.cuda.device() > 1:
+      model = nn.DataParallel(model)
+      parallel = True
+    
     optimizer = optim.Adam(model.parameters(), lr = args.learning_rate)
     scheduler = lr_scheduler.StepLR(optimizer, step_size = 50, gamma = 0.1)
     
@@ -124,9 +129,14 @@ def train_valid(model, optimizer, scheduler, epoch, dataloaders, data_size):
                 pos_hard_cls   = pos_cls[hard_triplets].to(device)
                 neg_hard_cls   = neg_cls[hard_triplets].to(device)
             
-                anc_img_pred   = model.forward_classifier(anc_hard_img).to(device)
-                pos_img_pred   = model.forward_classifier(pos_hard_img).to(device)
-                neg_img_pred   = model.forward_classifier(neg_hard_img).to(device)
+                if parallel:
+                    anc_img_pred   = model.module.forward_classifier(anc_hard_img).to(device)
+                    pos_img_pred   = model.module.forward_classifier(pos_hard_img).to(device)
+                    neg_img_pred   = model.module.forward_classifier(neg_hard_img).to(device)
+                else:
+                    anc_img_pred   = model.forward_classifier(anc_hard_img).to(device)
+                    pos_img_pred   = model.forward_classifier(pos_hard_img).to(device)
+                    neg_img_pred   = model.forward_classifier(neg_hard_img).to(device)            
             
                 triplet_loss   = TripletLoss(args.margin).forward(anc_hard_embed, pos_hard_embed, neg_hard_embed).to(device)
         


### PR DESCRIPTION
# DATA PARALLEL

When I trained the ***FaceNet model*** using your repository, the default batch size of 128 was too much memory for just one GPU. 

Instead, I added the power of `nn.DataParallel` not only to be able to train the model on a batch size of 128, but it also speeds the process of training. 